### PR TITLE
Resolve Rollup ES Module Configuration Error and Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,26 @@ This repo shares our implementation of **IndieLabel**—an interactive web appli
     ```
 
 - Concurrently build and run the Svelte app in another terminal session:
+    First, navigate to the Svelte application directory and install dependencies:
     ```
     $ cd indie_label_svelte/
+    $ npm install
+    ```
+    Then, start the development server. Depending on your operating system, use the appropriate command to set environment variables and run the server:
+
+    **For Unix-like systems (Linux, macOS):**
+    ```
     $ HOST=0.0.0.0 PORT=5000 npm run dev autobuild
+    ```
+    
+    **For Windows Command Prompt:**
+    ```
+    set HOST=0.0.0.0 && set PORT=5000 && npm run dev autobuild
+    ```
+    
+    **For Windows PowerShell:**
+    ```powershell
+    $env:HOST="0.0.0.0"; $env:PORT="5000"; npm run dev autobuild
     ```
 
 - You can now visit `localhost:5001` to view the IndieLabel app!

--- a/indie_label_svelte/package.json
+++ b/indie_label_svelte/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/StanfordHCI/indie-label/issues"
   },
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",


### PR DESCRIPTION
A couple other changes which allowed me to deploy the app locally with no issues.
- Added `"type": "module"` in `package.json` to address Rollup ES module loading errors.
- Updated README with environment-specific instructions based on specific operating system and explicitly telling users to run "npm install" to install dependencies

